### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/assets/vendor/php-email-form/validate.js
+++ b/assets/vendor/php-email-form/validate.js
@@ -76,9 +76,22 @@
     });
   }
 
+  function escapeHTML(str) {
+    return str.replace(/[&<>"']/g, function(match) {
+      const escapeMap = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      };
+      return escapeMap[match];
+    });
+  }
+
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').innerHTML = escapeHTML(error.toString());
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bobbydomdomjr/ePortfolio/security/code-scanning/1](https://github.com/bobbydomdomjr/ePortfolio/security/code-scanning/1)

To fix the issue, the `error` variable should be sanitized or escaped before being inserted into the DOM. This ensures that any potentially malicious content is neutralized and cannot execute as HTML or JavaScript. The best approach is to use a library or function that escapes special characters (e.g., `<`, `>`, `&`, `"`), converting them into their HTML entity equivalents. This prevents the browser from interpreting the content as executable code.

The fix involves:
1. Adding a utility function to escape HTML special characters.
2. Modifying the `displayError` function to sanitize the `error` variable before assigning it to `innerHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
